### PR TITLE
 Avoid NPE if description is missing.

### DIFF
--- a/analysis/src/main/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReader.java
+++ b/analysis/src/main/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReader.java
@@ -109,12 +109,18 @@ public class AsciiDocRuleSetReader implements RuleSetReader {
         for (ContentPart part : findExecutableRules(doc.getParts())) {
             Map<String, Object> attributes = part.getAttributes();
             String id = part.getId();
-            String description = attributes.get(TITLE).toString();
+            String description = "";
+            Object title = attributes.get(TITLE);
+            if(title != null){
+        	description = title.toString();
+            } else {
+        	LOGGER.info("Description of rule is missing: Using empty text for description (source='{}', id='{}').", ruleSource.getId(), id);
+            }
             Set<String> requiresConcepts = new HashSet<>(getDependencies(attributes, REQUIRES_CONCEPTS).keySet());
             Set<String> depends = getDependencies(attributes, DEPENDS).keySet();
             if (!depends.isEmpty()) {
                 LOGGER.info(
-                        "Using 'depends' to reference required concepts is deprecated, please use 'requiresConcepts' (source='{}', id='{}'}.",
+                        "Using 'depends' to reference required concepts is deprecated, please use 'requiresConcepts' (source='{}', id='{}').",
                         ruleSource.getId(), id);
                 requiresConcepts.addAll(depends);
             }

--- a/analysis/src/test/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReaderTest.java
+++ b/analysis/src/test/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReaderTest.java
@@ -4,30 +4,17 @@ import com.buschmais.jqassistant.core.analysis.api.rule.*;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
-
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import static org.junit.Assert.fail;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.collection.IsEmptyCollection;
-import org.hamcrest.core.IsCollectionContaining;
-import org.junit.Test;
-
-import com.buschmais.jqassistant.core.analysis.api.rule.*;
-import com.buschmais.jqassistant.core.analysis.api.rule.source.RuleSource;
-import com.buschmais.jqassistant.core.analysis.api.rule.source.UrlRuleSource;
 
 public class AsciiDocRuleSetReaderTest {
 
@@ -114,5 +101,21 @@ public class AsciiDocRuleSetReaderTest {
         assertThat(includedGroups.keySet(), hasItems("test:Group"));
         Group group = groups.getById("test:Group");
         assertThat(group, notNullValue());
+    }
+    
+    @Test
+    public void brokenRules() throws Exception {
+	RuleSet ruleSet = RuleSetTestHelper.readRuleSet("/broken-rules.adoc");
+	assertThat(ruleSet.getConceptBucket().getIds(), hasItems("test:MissingDescription"));
+	
+	ConceptBucket concepts = ruleSet.getConceptBucket();
+	try {
+	    concepts.getById("test:MissingCodeFragment");
+	    fail("Concept has no code fragment, should have fail!");
+	} catch (NoConceptException e) {
+	    // expected
+	}
+	
+        
     }
 }

--- a/analysis/src/test/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReaderTest.java
+++ b/analysis/src/test/java/com/buschmais/jqassistant/core/analysis/impl/AsciiDocRuleSetReaderTest.java
@@ -111,7 +111,7 @@ public class AsciiDocRuleSetReaderTest {
 	ConceptBucket concepts = ruleSet.getConceptBucket();
 	try {
 	    concepts.getById("test:MissingCodeFragment");
-	    fail("Concept has no code fragment, should have fail!");
+	    fail("Concept has no code fragment, should have failed!");
 	} catch (NoConceptException e) {
 	    // expected
 	}

--- a/analysis/src/test/resources/broken-rules.adoc
+++ b/analysis/src/test/resources/broken-rules.adoc
@@ -1,0 +1,18 @@
+= Rules
+
+== Concepts
+
+[[test:MissingDescription]]
+
+[source,cypher,role=concept]
+----
+match
+  (n)
+return
+  n
+----
+
+
+[[test:MissingCodeFragment]]
+.Test text
+[source,cypher,role=concept]


### PR DESCRIPTION
If the text / description for a concept or constraint is missing in ASCIIDoc, an NullPointerException occurs. This fix sets an empty string as default and logs a missing description to avoid this.