### PR TITLE
refrain from using internal implementation (OSGi)

### DIFF
--- a/store/src/main/java/com/buschmais/jqassistant/core/store/impl/EmbeddedGraphStore.java
+++ b/store/src/main/java/com/buschmais/jqassistant/core/store/impl/EmbeddedGraphStore.java
@@ -9,8 +9,8 @@ import com.buschmais.xo.api.XOManagerFactory;
 import com.buschmais.xo.api.bootstrap.XO;
 import com.buschmais.xo.api.bootstrap.XOUnit;
 import com.buschmais.xo.api.bootstrap.XOUnitBuilder;
+import com.buschmais.xo.neo4j.api.Neo4jDatastoreSession;
 import com.buschmais.xo.neo4j.api.Neo4jXOProvider;
-import com.buschmais.xo.neo4j.impl.datastore.EmbeddedNeo4jDatastoreSession;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -46,7 +46,7 @@ public class EmbeddedGraphStore extends AbstractGraphStore {
 
     @Override
     protected GraphDatabaseService getGraphDatabaseService(XOManager xoManager) {
-        return xoManager.getDatastoreSession(EmbeddedNeo4jDatastoreSession.class).getGraphDatabaseService();
+        return xoManager.getDatastoreSession(Neo4jDatastoreSession.class).getGraphDatabaseService();
     }
 
     @Override


### PR DESCRIPTION
It should not be necessary to use internal implementation here; in particular since the "com.buschmais.xo.neo4j.impl.*" packages get not exported and thus are not visible here